### PR TITLE
Added 60dB integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@
 
 Adds Text-to-Speech to things like Claude Desktop and Cursor IDE.  
 
-It registers four TTS tools: 
+It registers five TTS tools: 
  - `say_tts` 
  - `elevenlabs_tts`
  - `google_tts`
  - `openai_tts`
+ - `sixtydb_tts`
 
 ### `say_tts`
 
@@ -62,6 +63,16 @@ Supports three quality models:
 Additional features:
 - Speed control from 0.25x to 4.0x (default: 1.0x)
 - Custom voice instructions (e.g., "Speak in a cheerful and positive tone") via parameter or `OPENAI_TTS_INSTRUCTIONS` environment variable
+
+### `sixtydb_tts`
+
+Uses the [60dB](https://60db.ai) text-to-speech API to speak the text with high-quality AI voices. Returns MP3 audio.
+
+Configuration via environment variables:
+- `SIXTYDB_API_KEY` (required)
+- `SIXTYDB_VOICE_ID` (optional) — when unset, 60dB uses the account's default voice. List your voices via the [`/myvoices`](https://docs.60db.ai/api-reference/voices/get-my-voices) endpoint.
+
+The request uses sensible defaults (speed `1.0`, stability `50`, similarity `75`, enhancement on) on 60dB's 0–100 settings scale.
 
 ## Configuration
 
@@ -125,6 +136,7 @@ Files are saved with unique names: `tts_{timestamp}_{hash}.{ext}`
 | ElevenLabs | MP3 |
 | Google TTS | WAV |
 | OpenAI TTS | MP3 |
+| 60dB | MP3 |
 
 ## Getting Started
 
@@ -145,6 +157,7 @@ Provides multiple text-to-speech services via MCP protocol:
 • elevenlabs_tts - Uses ElevenLabs API for high-quality speech synthesis
 • google_tts - Uses Google's Gemini TTS models for natural speech
 • openai_tts - Uses OpenAI's TTS API with various voice options
+• sixtydb_tts - Uses the 60dB API for high-quality speech synthesis
 
 Each tool supports different voices, rates, and configuration options.
 Requires appropriate API keys for cloud-based services.
@@ -180,6 +193,8 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
         "GOOGLE_AI_API_KEY": "********",
         "OPENAI_API_KEY": "********",
         "OPENAI_TTS_INSTRUCTIONS": "Speak in a cheerful and positive tone",
+        "SIXTYDB_API_KEY": "********",
+        "SIXTYDB_VOICE_ID": "",
         "MCP_TTS_SUPPRESS_SPEAKING_OUTPUT": "true",
         "MCP_TTS_ALLOW_CONCURRENT": "false"
       }
@@ -239,6 +254,8 @@ Or manually add to `~/.gemini/settings.json` (or `.gemini/settings.json` in proj
 - `GOOGLE_AI_API_KEY` or `GEMINI_API_KEY`: Your Google AI API key (required for `google_tts`)
 - `OPENAI_API_KEY`: Your OpenAI API key (required for `openai_tts`)
 - `OPENAI_TTS_INSTRUCTIONS`: Custom voice instructions for OpenAI TTS (optional, e.g., "Speak in a cheerful and positive tone")
+- `SIXTYDB_API_KEY`: Your 60dB API key (required for `sixtydb_tts`)
+- `SIXTYDB_VOICE_ID`: 60dB voice ID (optional; when unset, 60dB uses the account's default voice — list your voices via the `/myvoices` endpoint)
 - `MCP_TTS_SUPPRESS_SPEAKING_OUTPUT`: Set to "true" to suppress "Speaking:" output (optional)
 - `MCP_TTS_ALLOW_CONCURRENT`: Set to "true" to allow concurrent TTS operations (optional, defaults to sequential)
 - `MCP_TTS_OUTPUT_DIR`: Directory to save audio files (optional)

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -32,6 +32,7 @@ const (
 	ProviderElevenLabs = "elevenlabs_tts"
 	ProviderGoogle     = "google_tts"
 	ProviderOpenAI     = "openai_tts"
+	ProviderSixtyDB    = "sixtydb_tts"
 )
 
 // Default values for provider-specific settings.
@@ -47,6 +48,15 @@ const (
 	// default must be a premade voice.
 	DefaultElevenLabsVoiceID = "EXAVITQu4vr4xnSDxMaL"
 	DefaultElevenLabsModel   = "eleven_v3"
+	// 60dB defaults. There is no public premade voice ID: when
+	// SIXTYDB_VOICE_ID is unset the voice_id field is omitted and 60dB uses the
+	// account's system default voice. Stability/similarity are on a 0-100 scale.
+	DefaultSixtyDBSpeed      = 1.0
+	DefaultSixtyDBStability  = 50
+	DefaultSixtyDBSimilarity = 75
+	// DefaultSixtyDBOutputFormat is mp3 so the response routes through the
+	// shared playMP3/saveMP3 path, matching ElevenLabs.
+	DefaultSixtyDBOutputFormat = "mp3"
 )
 
 // Voice and model lists shared by tool schemas (schemas.go) and
@@ -94,6 +104,9 @@ func availableProviders() []providerOption {
 	}
 	if os.Getenv("OPENAI_API_KEY") != "" {
 		providers = append(providers, providerOption{ProviderOpenAI, "OpenAI"})
+	}
+	if os.Getenv("SIXTYDB_API_KEY") != "" {
+		providers = append(providers, providerOption{ProviderSixtyDB, "60dB"})
 	}
 	return providers
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -362,6 +363,10 @@ type ElevenLabsTTSParams struct {
 	Text string `json:"text" mcp:"The text to convert to speech using ElevenLabs API"`
 }
 
+type SixtyDBTTSParams struct {
+	Text string `json:"text" mcp:"The text to convert to speech using the 60dB API"`
+}
+
 type GoogleTTSParams struct {
 	Text  string  `json:"text" mcp:"The text to convert to speech using Google TTS"`
 	Voice *string `json:"voice,omitempty,omitzero" mcp:"Voice name to use (e.g. 'Kore', 'Puck', 'Fenrir', etc. - see documentation for full list of 30 voices, default: 'Kore')"`
@@ -440,6 +445,7 @@ Provides multiple text-to-speech services via MCP protocol:
 • elevenlabs_tts - Uses ElevenLabs API for high-quality speech synthesis
 • google_tts - Uses Google's Gemini TTS models for natural speech
 • openai_tts - Uses OpenAI's TTS API with various voice options
+• sixtydb_tts - Uses the 60dB API for high-quality speech synthesis
 
 Each tool supports different voices, rates, and configuration options.
 Requires appropriate API keys for cloud-based services.
@@ -518,6 +524,12 @@ Designed to be used with the MCP (Model Context Protocol).`,
 		// ElevenLabs icon (stylized "XI" or wave pattern)
 		elevenLabsIcon := mcp.Icon{
 			Source:   "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSJjdXJyZW50Q29sb3IiIGQ9Ik03IDRoMnYxNkg3em04IDBoMnYxNmgtMnoiLz48L3N2Zz4=",
+			MIMEType: "image/svg+xml",
+			Sizes:    []string{"24x24"},
+		}
+		// 60dB icon (audio waveform bars)
+		sixtyDBIcon := mcp.Icon{
+			Source:   "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiPjxwYXRoIGQ9Ik00IDEwdjRNOCA2djEyTTEyIDl2Nk0xNiA0djE2TTIwIDh2OCIvPjwvc3ZnPg==",
 			MIMEType: "image/svg+xml",
 			Sizes:    []string{"24x24"},
 		}
@@ -768,6 +780,133 @@ Designed to be used with the MCP (Model Context Protocol).`,
 
 			return deliverAudio(text, audioData, saveMP3, func() error {
 				return playMP3("elevenlabs_tts", audioData)
+			})
+		})
+
+		// Add the "sixtydb_tts" tool
+		sixtyDBTool := &mcp.Tool{
+			Name:        "sixtydb_tts",
+			Title:       "60dB",
+			Description: "Uses the 60dB API to generate speech from text",
+			InputSchema: buildSixtyDBTTSSchema(),
+			Icons:       []mcp.Icon{sixtyDBIcon},
+			Annotations: &mcp.ToolAnnotations{
+				Title:          "60dB Text-to-Speech",
+				ReadOnlyHint:   false,
+				IdempotentHint: true,
+			},
+		}
+
+		mcp.AddTool(s, sixtyDBTool, func(ctx context.Context, _ *mcp.CallToolRequest, input SixtyDBTTSParams) (*mcp.CallToolResult, any, error) {
+			select {
+			case <-ctx.Done():
+				return textResult("Request cancelled"), nil, nil
+			default:
+			}
+
+			log.Debug("60dB tool called", "params", input)
+			text := input.Text
+			if text == "" {
+				return errorResult("Error: text must be a string"), nil, nil
+			}
+
+			apiKey := os.Getenv("SIXTYDB_API_KEY")
+			if apiKey == "" {
+				log.Error("SIXTYDB_API_KEY not set")
+				return errorResult("Error: SIXTYDB_API_KEY is not set"), nil, nil
+			}
+
+			// voice_id is optional: when unset, 60dB uses the account's default
+			// voice. The model is selected via the voice, so there is no model_id.
+			voiceID := os.Getenv("SIXTYDB_VOICE_ID")
+			if voiceID == "" {
+				log.Debug("Voice not specified, using 60dB account default")
+			}
+
+			// Fetch the audio synchronously so HTTP/API errors surface to the
+			// caller, then hand playback off to the background.
+			const url = "https://api.60db.ai/tts-synthesize"
+			params := SixtyDBParams{
+				Text:         text,
+				VoiceID:      voiceID,
+				Speed:        DefaultSixtyDBSpeed,      // 0.5-2.0
+				Stability:    DefaultSixtyDBStability,  // 0-100; lower = more expressive
+				Similarity:   DefaultSixtyDBSimilarity, // 0-100; voice matching level
+				Enhance:      true,
+				OutputFormat: DefaultSixtyDBOutputFormat, // mp3, routed through playMP3/saveMP3
+			}
+
+			b, err := json.Marshal(params)
+			if err != nil {
+				log.Error("Failed to marshal request body", "error", err)
+				return errorResult(fmt.Sprintf("Error: failed to marshal request body: %v", err)), nil, nil
+			}
+
+			log.Debug("Making 60dB API request", "url", url, "voice", voiceID, "text", text)
+			httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(b))
+			if err != nil {
+				log.Error("Failed to create request", "error", err)
+				return errorResult(fmt.Sprintf("Error: failed to create request: %v", err)), nil, nil
+			}
+			httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+			httpReq.Header.Set("Content-Type", "application/json")
+			httpReq.Header.Set("accept", "application/json")
+
+			safeLog("Sending HTTP request", httpReq)
+			res, err := http.DefaultClient.Do(httpReq)
+			if err != nil {
+				if ctx.Err() != nil {
+					return textResult("Request cancelled"), nil, nil
+				}
+				log.Error("Failed to send request", "error", err)
+				return errorResult(fmt.Sprintf("Error: failed to send request: %v", err)), nil, nil
+			}
+			defer res.Body.Close()
+
+			body, err := io.ReadAll(res.Body)
+			if err != nil {
+				if ctx.Err() != nil {
+					return textResult("Request cancelled"), nil, nil
+				}
+				log.Error("Failed to read 60dB response", "error", err)
+				return errorResult(fmt.Sprintf("Error: failed to read response: %v", err)), nil, nil
+			}
+
+			if res.StatusCode != http.StatusOK {
+				log.Error("60dB request failed", "status", res.Status, "body", string(body))
+				if len(body) > 0 {
+					return errorResult(fmt.Sprintf("Error: 60dB API error (status %d): %s", res.StatusCode, string(body))), nil, nil
+				}
+				return errorResult(fmt.Sprintf("Error: 60dB API error: status %d %s", res.StatusCode, res.Status)), nil, nil
+			}
+
+			var parsed SixtyDBResponse
+			if err := json.Unmarshal(body, &parsed); err != nil {
+				log.Error("Failed to decode 60dB response", "error", err)
+				return errorResult(fmt.Sprintf("Error: failed to decode 60dB response: %v", err)), nil, nil
+			}
+			if !parsed.Success {
+				msg := parsed.Message
+				if msg == "" {
+					msg = "request was not successful"
+				}
+				log.Error("60dB synthesis failed", "message", msg)
+				return errorResult(fmt.Sprintf("Error: 60dB API error: %s", msg)), nil, nil
+			}
+			if parsed.AudioBase64 == "" {
+				log.Error("60dB response contained no audio")
+				return errorResult("Error: 60dB API returned no audio"), nil, nil
+			}
+
+			audioData, err := base64.StdEncoding.DecodeString(parsed.AudioBase64)
+			if err != nil {
+				log.Error("Failed to decode 60dB audio", "error", err)
+				return errorResult(fmt.Sprintf("Error: failed to decode 60dB audio: %v", err)), nil, nil
+			}
+			log.Debug("60dB audio received", "bytes", len(audioData))
+
+			return deliverAudio(text, audioData, saveMP3, func() error {
+				return playMP3("sixtydb_tts", audioData)
 			})
 		})
 
@@ -1119,6 +1258,9 @@ func safeLog(message string, req *http.Request) {
 	reqCopy := req.Clone(context.Background())
 	if _, exists := reqCopy.Header["Xi-Api-Key"]; exists {
 		reqCopy.Header["Xi-Api-Key"] = []string{"******"} // Mask password
+	}
+	if _, exists := reqCopy.Header["Authorization"]; exists {
+		reqCopy.Header["Authorization"] = []string{"******"} // Mask bearer token
 	}
 	log.With(reqCopy).Debug(message)
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -606,6 +606,83 @@ func TestElevenLabsTTSTool(t *testing.T) {
 	}
 }
 
+func TestSixtyDBTTSTool(t *testing.T) {
+	// Set up test environment variables
+	originalAPIKey := os.Getenv("SIXTYDB_API_KEY")
+	defer func() {
+		if originalAPIKey != "" {
+			os.Setenv("SIXTYDB_API_KEY", originalAPIKey)
+		} else {
+			os.Unsetenv("SIXTYDB_API_KEY")
+		}
+	}()
+
+	tests := []struct {
+		name          string
+		setupEnv      func()
+		params        SixtyDBTTSParams
+		expectError   bool
+		shouldContain []string
+	}{
+		{
+			name: "missing API key",
+			setupEnv: func() {
+				os.Unsetenv("SIXTYDB_API_KEY")
+			},
+			params: SixtyDBTTSParams{
+				Text: "Hello",
+			},
+			expectError:   true,
+			shouldContain: []string{"SIXTYDB_API_KEY is not set"},
+		},
+		{
+			name: "empty text",
+			setupEnv: func() {
+				os.Setenv("SIXTYDB_API_KEY", "test-api-key")
+			},
+			params: SixtyDBTTSParams{
+				Text: "",
+			},
+			expectError:   true,
+			shouldContain: []string{"text must be a string"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup environment
+			tt.setupEnv()
+
+			ctx := context.Background()
+			params := &TestCallToolParams[SixtyDBTTSParams]{
+				Name:      "sixtydb_tts",
+				Arguments: tt.params,
+			}
+
+			// Call the handler directly
+			result, err := callSixtyDBTTSHandler(ctx, params)
+
+			if tt.expectError {
+				require.NotNil(t, result)
+				assert.True(t, result.IsError, "Expected error but got success")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				assert.False(t, result.IsError, "Expected success but got error: %v", result)
+			}
+
+			// Check that result contains expected strings
+			if len(tt.shouldContain) > 0 {
+				resultText := extractTextFromResult(result)
+				for _, expectedStr := range tt.shouldContain {
+					assert.Contains(t, resultText, expectedStr,
+						"Result should contain '%s', but got: %s", expectedStr, resultText)
+				}
+			}
+		})
+	}
+}
+
 func TestParameterValidation(t *testing.T) {
 	t.Run("SayTTSParams", func(t *testing.T) {
 		tests := []struct {
@@ -752,6 +829,31 @@ func callElevenLabsTTSHandler(ctx context.Context, params *TestCallToolParams[El
 	if apiKey == "" {
 		return &TestCallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "Error: ELEVENLABS_API_KEY is not set"}},
+			IsError: true,
+		}, nil
+	}
+
+	// Mock successful execution
+	responseText := fmt.Sprintf("Speaking: %s", params.Arguments.Text)
+	return &TestCallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: responseText}},
+	}, nil
+}
+
+func callSixtyDBTTSHandler(ctx context.Context, params *TestCallToolParams[SixtyDBTTSParams]) (*TestCallToolResult, error) {
+	// Mock implementation that simulates the 60dB handler logic
+	if params.Arguments.Text == "" {
+		return &TestCallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "Error: text must be a string"}},
+			IsError: true,
+		}, nil
+	}
+
+	// Check API key
+	apiKey := os.Getenv("SIXTYDB_API_KEY")
+	if apiKey == "" {
+		return &TestCallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "Error: SIXTYDB_API_KEY is not set"}},
 			IsError: true,
 		}, nil
 	}
@@ -949,6 +1051,41 @@ func TestCancellation(t *testing.T) {
 		cancel()
 
 		result, err := callCancellableElevenLabsTTSHandler(ctx, params)
+
+		// Should handle cancellation gracefully
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		resultText := extractTextFromResult(result)
+		assert.Contains(t, resultText, "cancelled", "Should indicate cancellation")
+	})
+
+	t.Run("60dB TTS cancellation", func(t *testing.T) {
+		// Set up test environment
+		originalAPIKey := os.Getenv("SIXTYDB_API_KEY")
+		os.Setenv("SIXTYDB_API_KEY", "test-api-key")
+		defer func() {
+			if originalAPIKey != "" {
+				os.Setenv("SIXTYDB_API_KEY", originalAPIKey)
+			} else {
+				os.Unsetenv("SIXTYDB_API_KEY")
+			}
+		}()
+
+		// Create a context that we can cancel
+		ctx, cancel := context.WithCancel(context.Background())
+
+		params := &TestCallToolParams[SixtyDBTTSParams]{
+			Name: "sixtydb_tts",
+			Arguments: SixtyDBTTSParams{
+				Text: "This should be cancelled",
+			},
+		}
+
+		// Cancel immediately to test early cancellation detection
+		cancel()
+
+		result, err := callCancellableSixtyDBTTSHandler(ctx, params)
 
 		// Should handle cancellation gracefully
 		require.NoError(t, err)
@@ -1155,6 +1292,52 @@ func callCancellableElevenLabsTTSHandler(ctx context.Context, params *TestCallTo
 	if apiKey == "" {
 		return &TestCallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "Error: ELEVENLABS_API_KEY is not set"}},
+			IsError: true,
+		}, nil
+	}
+
+	// Simulate processing with cancellation checks
+	for range 3 {
+		select {
+		case <-ctx.Done():
+			return &TestCallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "Audio playback cancelled"}},
+			}, nil
+		case <-time.After(10 * time.Millisecond):
+			// Continue processing
+		}
+	}
+
+	// Mock successful execution
+	responseText := fmt.Sprintf("Speaking: %s", params.Arguments.Text)
+	return &TestCallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: responseText}},
+	}, nil
+}
+
+func callCancellableSixtyDBTTSHandler(ctx context.Context, params *TestCallToolParams[SixtyDBTTSParams]) (*TestCallToolResult, error) {
+	// Check for early cancellation
+	select {
+	case <-ctx.Done():
+		return &TestCallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "Request cancelled"}},
+		}, nil
+	default:
+	}
+
+	// Basic validation
+	if params.Arguments.Text == "" {
+		return &TestCallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "Error: text must be a string"}},
+			IsError: true,
+		}, nil
+	}
+
+	// Check API key
+	apiKey := os.Getenv("SIXTYDB_API_KEY")
+	if apiKey == "" {
+		return &TestCallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "Error: SIXTYDB_API_KEY is not set"}},
 			IsError: true,
 		}, nil
 	}

--- a/cmd/schemas.go
+++ b/cmd/schemas.go
@@ -65,6 +65,24 @@ func buildElevenLabsTTSSchema() json.RawMessage {
 	return data
 }
 
+func buildSixtyDBTTSSchema() json.RawMessage {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"text": map[string]any{
+				"type":        "string",
+				"description": "The text to convert to speech using the 60dB API",
+			},
+		},
+		"required": []string{"text"},
+	}
+	data, err := json.Marshal(schema)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal sixtydb_tts schema: %v", err))
+	}
+	return data
+}
+
 func buildGoogleTTSSchema() json.RawMessage {
 	schema := map[string]any{
 		"type": "object",

--- a/cmd/sixtydb.go
+++ b/cmd/sixtydb.go
@@ -1,0 +1,31 @@
+package cmd
+
+// SixtyDBParams is the JSON request body for the 60dB text-to-speech endpoint
+// (POST https://api.60db.ai/tts-synthesize). Mirrors the structure used for
+// ElevenLabs (see elevenlabs.go), adapted to 60dB's flat field layout.
+//
+// Note: 60dB scales stability/similarity on 0-100 (unlike ElevenLabs' 0.0-1.0)
+// and selects the model via the voice itself ("60db Fast" / "60db Quality"),
+// so there is no separate model_id field.
+type SixtyDBParams struct {
+	Text         string  `json:"text"`
+	VoiceID      string  `json:"voice_id,omitempty"`
+	Speed        float64 `json:"speed"`
+	Stability    int     `json:"stability"`
+	Similarity   int     `json:"similarity"`
+	Enhance      bool    `json:"enhance"`
+	OutputFormat string  `json:"output_format,omitempty"`
+}
+
+// SixtyDBResponse is the JSON response body returned by the 60dB
+// tts-synthesize endpoint. The synthesized audio is base64-encoded in
+// AudioBase64 (unlike ElevenLabs, which streams raw audio bytes).
+type SixtyDBResponse struct {
+	Success         bool    `json:"success"`
+	Message         string  `json:"message"`
+	AudioBase64     string  `json:"audio_base64"`
+	SampleRate      int     `json:"sample_rate"`
+	DurationSeconds float64 `json:"duration_seconds"`
+	Encoding        string  `json:"encoding"`
+	OutputFormat    string  `json:"output_format"`
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@
 ## 🏗️ **Architecture**
 
 ### **Core Components**
-- **`cmd/root.go`** - Main MCP server with 4 TTS tools (say, ElevenLabs, Google, OpenAI)
+- **`cmd/root.go`** - Main MCP server with 5 TTS tools (say, ElevenLabs, Google, OpenAI, 60dB)
 - **`cmd/cancellation_manager.go`** - Request tracking and cancellation system
 - **`cmd/cancellable_wrapper.go`** - Tool wrapper providing cancellation support
 - **`cmd/notification_handler.go`** - MCP cancellation notification processing
@@ -29,6 +29,7 @@
 2. **`elevenlabs_tts`** - ElevenLabs API integration
 3. **`google_tts`** - Google Gemini TTS models
 4. **`openai_tts`** - OpenAI TTS API integration
+5. **`sixtydb_tts`** - 60dB API integration
 
 ### **Security Features**
 - ✅ Request ID sanitization and validation
@@ -45,11 +46,13 @@
 export OPENAI_API_KEY="your-openai-key"
 export ELEVENLABS_API_KEY="your-elevenlabs-key"  
 export GOOGLE_AI_API_KEY="your-google-key"
+export SIXTYDB_API_KEY="your-60db-key"
 
 # Optional configuration
 export OPENAI_TTS_INSTRUCTIONS="Custom voice instructions"
 export ELEVENLABS_VOICE_ID="custom-voice-id"
 export ELEVENLABS_MODEL_ID="custom-model-id"
+export SIXTYDB_VOICE_ID="custom-voice-id"
 ```
 
 ### **MCP Tools**
@@ -99,6 +102,16 @@ All tools support cancellation via MCP `notifications/cancelled` protocol.
     "model": "gpt-4o-mini-tts",
     "speed": 1.0,
     "instructions": "Speak clearly and professionally"
+  }
+}
+```
+
+#### **sixtydb_tts**
+```json
+{
+  "name": "sixtydb_tts",
+  "arguments": {
+    "text": "Text to speak"
   }
 }
 ```

--- a/integration_test.go
+++ b/integration_test.go
@@ -67,6 +67,11 @@ type ElevenLabsArgs struct {
 	Text string `json:"text"`
 }
 
+// SixtyDBArgs for sixtydb_tts tool
+type SixtyDBArgs struct {
+	Text string `json:"text"`
+}
+
 // GoogleTTSArgs for google_tts tool
 type GoogleTTSArgs struct {
 	Text  string  `json:"text"`
@@ -641,7 +646,7 @@ func TestMCPIntegration_ToolsList(t *testing.T) {
 		toolNames = append(toolNames, name)
 	}
 
-	expectedTools := []string{"elevenlabs_tts", "google_tts", "openai_tts", "tts"}
+	expectedTools := []string{"elevenlabs_tts", "google_tts", "openai_tts", "sixtydb_tts", "tts"}
 
 	// On macOS, we should also have say_tts
 	if os.Getenv("GITHUB_ACTIONS") == "" { // Not in CI
@@ -774,6 +779,46 @@ func TestMCPIntegration_ElevenLabsTTS(t *testing.T) {
 	}
 
 	assert.NotNil(t, response.Result, "elevenlabs_tts should return result")
+
+	// Verify the result structure
+	result, ok := response.Result.(map[string]any)
+	require.True(t, ok, "Result should be a map")
+
+	content, ok := result["content"].([]any)
+	require.True(t, ok, "Result should contain content array")
+	require.Len(t, content, 1, "Should have one content item")
+
+	textContent, ok := content[0].(map[string]any)
+	require.True(t, ok, "Content should be a map")
+
+	text, ok := textContent["text"].(string)
+	require.True(t, ok, "Content should have text")
+
+	requireSpeakingOrSkip(t, text)
+}
+
+func TestMCPIntegration_SixtyDBTTS(t *testing.T) {
+	if os.Getenv("SIXTYDB_API_KEY") == "" {
+		t.Skip("Skipping 60dB test: SIXTYDB_API_KEY not set")
+	}
+
+	runner := NewMCPTestRunner(t)
+	defer runner.Close()
+
+	args := SixtyDBArgs{
+		Text: "Hello, world! This is a test of 60dB TTS integration.",
+	}
+
+	response, err := runner.callTool(4, "sixtydb_tts", args)
+	require.NoError(t, err, "sixtydb_tts call should succeed")
+
+	if response.Error != nil {
+		t.Logf("sixtydb_tts error: %v", response.Error)
+		// Don't fail if API key is invalid or API is unavailable
+		return
+	}
+
+	assert.NotNil(t, response.Result, "sixtydb_tts should return result")
 
 	// Verify the result structure
 	result, ok := response.Result.(map[string]any)

--- a/test/json/sixtydb.json
+++ b/test/json/sixtydb.json
@@ -1,0 +1,2 @@
+{"jsonrpc":"2.0","id":1,"params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"example-client","version":"1.0.0"},"capabilities":{}},"method":"initialize"}
+{"jsonrpc":"2.0","id":4,"params":{"name":"sixtydb_tts","arguments":{"text":"Hello, world! Wanna hear a joke? Knock knock... to get to the other side. ha HA!"}},"method":"tools/call"}


### PR DESCRIPTION
We added a 60dB text-to-speech backend (sixtydb_tts) to the mcp-tts MCP server, built to match the existing ElevenLabs tool.

  - New tool sixtydb_tts that sends text to POST https://api.60db.ai/tts-synthesize with Authorization: Bearer $SIXTYDB_API_KEY,
  decodes the base64 audio from the JSON response, and plays/saves it as MP3 via the shared pipeline.
  - Config via SIXTYDB_API_KEY (required) and SIXTYDB_VOICE_ID (optional), with sensible hardcoded defaults (speed 1.0, stability
  50, similarity 75, enhance on).
  - Supporting wiring: request/response types, text-only schema, provider registry entry, an icon, Authorization-header masking in
  logs, plus unit/cancellation/integration tests and README docs.

  In short: the server now supports 60dB as a fifth TTS provider alongside macOS say, ElevenLabs, Google, and OpenAI.